### PR TITLE
Fix app crash when workspace folder does not exist

### DIFF
--- a/src/GitLurker.Core/Services/RepositoryService.cs
+++ b/src/GitLurker.Core/Services/RepositoryService.cs
@@ -1,6 +1,7 @@
 ﻿namespace GitLurker.Core.Services;
 
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using GitLurker.Core.Models;
 
@@ -58,7 +59,7 @@ public class RepositoryService
         var settingsFile = new SettingsFile();
         settingsFile.Initialize();
 
-        _workspaces = settingsFile.Entity.Workspaces.Select(w => new Workspace(w)).ToArray();
+        _workspaces = settingsFile.Entity.Workspaces.Where(Directory.Exists).Select(w => new Workspace(w)).ToArray();
         return _workspaces;
     }
 

--- a/src/GitLurker.UI/ViewModels/FolderViewModel.cs
+++ b/src/GitLurker.UI/ViewModels/FolderViewModel.cs
@@ -2,7 +2,6 @@
 
 using System;
 using System.IO;
-using System.Windows.Media;
 
 public class FolderViewModel
 {
@@ -27,7 +26,7 @@ public class FolderViewModel
 
     public string Folder => _folder;
 
-    public Brush Foreground => Directory.Exists(Folder) ? Brushes.Black : Brushes.Red;
+    public bool FolderExists => Directory.Exists(Folder);
 
     #endregion
 

--- a/src/GitLurker.UI/ViewModels/FolderViewModel.cs
+++ b/src/GitLurker.UI/ViewModels/FolderViewModel.cs
@@ -1,6 +1,8 @@
 ﻿namespace GitLurker.UI.ViewModels;
 
 using System;
+using System.IO;
+using System.Windows.Media;
 
 public class FolderViewModel
 {
@@ -24,6 +26,8 @@ public class FolderViewModel
     #region Properties
 
     public string Folder => _folder;
+
+    public Brush Foreground => Directory.Exists(Folder) ? Brushes.Black : Brushes.Red;
 
     #endregion
 

--- a/src/GitLurker.UI/Views/FolderView.xaml
+++ b/src/GitLurker.UI/Views/FolderView.xaml
@@ -16,8 +16,17 @@
                    Grid.Column="1"
                    Margin="10,0,0,0"
                    VerticalAlignment="Center"
-                   FontSize="22"
-                   Foreground="{Binding Foreground}" />
+                   FontSize="22" >
+            <TextBlock.Style>
+                <Style TargetType="TextBlock">
+                    <Style.Triggers>
+                        <DataTrigger Binding="{Binding FolderExists}" Value="false">
+                            <Setter Property="Foreground" Value="Red" />
+                        </DataTrigger>
+                    </Style.Triggers>
+                </Style>
+            </TextBlock.Style>
+        </TextBlock>
         <Button x:Name="Delete"
                 Grid.Column="0"
                 Margin="0,4,0,4"

--- a/src/GitLurker.UI/Views/FolderView.xaml
+++ b/src/GitLurker.UI/Views/FolderView.xaml
@@ -16,7 +16,8 @@
                    Grid.Column="1"
                    Margin="10,0,0,0"
                    VerticalAlignment="Center"
-                   FontSize="22" />
+                   FontSize="22"
+                   Foreground="{Binding Foreground}" />
         <Button x:Name="Delete"
                 Grid.Column="0"
                 Margin="0,4,0,4"


### PR DESCRIPTION
Whenever you remove a folder that was marked as a workspace, the app crashes on startup.

Proposed solution:
- Only add the workspaces with existing folders to the workspaces in RepositoryService
- Add visual indicator that the folder does not exist in the workspaces screen in the Settings section.